### PR TITLE
【fix】修复compile时，单标签闭合结点解析错误

### DIFF
--- a/《template 模板是怎样通过 Compile 编译的》.js
+++ b/《template 模板是怎样通过 Compile 编译的》.js
@@ -179,8 +179,10 @@ function parseHTML () {
                     currentParent.children.push(element);
                 }
         
-                stack.push(element);
-                currentParent = element;
+                if(!startTagMatch.unarySlash) {
+                    stack.push(element);
+                    currentParent = element;
+                }
                 continue;
             }
         } else {


### PR DESCRIPTION
unarySlash（一元斜线符），类似<img/>这种单标签闭合的元素，它们是不可以作为currentParent的。

否则，该结点后面的兄弟结点会被当做是该结点的孩子结点，出现错误。

**错误例子**

【source code】:

```html
<div><img src="logo.png"/><p>this is a text.</p></div>
```

【transformed ast】:

```json
{
  "type": 1,
  "tag": "div",
  "lowerCasedTag": "div",
  "attrsList": [],
  "attrsMap": {},
  "children": [
    {
      "type": 1,
      "tag": "img",
      "lowerCasedTag": "img",
      "attrsList": [
        {
          "name": "src",
          "value": "logo.png"
        }
      ],
      "attrsMap": {
        "src": "logo.png"
      },
      "children": [
        {
          "type": 1,
          "tag": "p",
          "lowerCasedTag": "p",
          "attrsList": [],
          "attrsMap": {},
          "children": [
            {
              "type": 3,
              "text": "this is a text."
            }
          ]
        }
      ]
    }
  ]
}
```