### PR TITLE
【fix】修复compile阶段genCode生成代码错误

### DIFF
--- a/《template 模板是怎样通过 Compile 编译的》.js
+++ b/《template 模板是怎样通过 Compile 编译的》.js
@@ -22,6 +22,8 @@ const defaultTagRE = /\{\{((?:.|\n)+?)\}\}/g
 
 const forAliasRE = /(.*?)\s+(?:in|of)\s+(.*)/
 
+const stripBracket = /^\(|\)$/g;
+
 const stack = [];
 let currentParent, root;
 
@@ -128,7 +130,7 @@ function processFor (el) {
     if ((exp = getAndRemoveAttr(el, 'v-for'))) {
         const inMatch = exp.match(forAliasRE);
         el.for = inMatch[2].trim();
-        el.alias = inMatch[1].trim();
+        el.alias = inMatch[1].trim().replace(stripBracket, '').trim();
     }
 }
 
@@ -292,7 +294,7 @@ function generate (rootAst) {
         const children = el.children;
 
         if (children && children.length > 0) {
-            return `${children.map(genNode).join(',')}`;
+            return `[${children.map(genNode).join(',')}]`;
         }
     }
 
@@ -304,9 +306,9 @@ function generate (rootAst) {
         } else {
             const children = genChildren(el);
             let code;
-            code = `_c('${el.tag},'{
+            code = `_c('${el.tag}',{
                 staticClass: ${el.attrsMap && el.attrsMap[':class']},
-                class: ${el.attrsMap && el.attrsMap['class']},
+                'class': ${el.attrsMap && el.attrsMap['class']},
             }${
                 children ? `,${children}` : ''
             })`


### PR DESCRIPTION
这里修复以下几个问题：

1. 在解析v-for时，只是简单得保存下了(of|in)两边的值分别作为alias和for。然后在genFor时，利用这两个值来构成一个function：

```javascript
function genFor (el) {
        el.forProcessed = true;

        const exp = el.for;
        const alias = el.alias;
        const iterator1 = el.iterator1 ? `,${el.iterator1}` : '';
        const iterator2 = el.iterator2 ? `,${el.iterator2}` : '';

        return `_l((${exp}),` +
            `function(${alias}${iterator1}${iterator2}){` +
            `return ${genElement(el)}` +
        '})';
    }
```

但是这里的处理有问题：

一是在解析v-for指令的时候，没有保存iterator1和iterator2，所以这里用到的iterator1和iterator2是没有意义的。看了vue的源码之后，其实源码在解析v-for时是有解析iterator1和iterator2的，作者应该是想降低复杂度，从简处理了。所以相应的，这里的iterator1和iterator2其实可以删除。

二是作者的processFor处理漏掉了一种情况，即alias是带括号的情况。举例：v-for="(val, key, idx) in data"时，作者的alias匹配得到的是(val, key, idx)，代入genFor中，得到的代码块就成了function((val, key, idx))，这就出错了。所以可以在作者的基础之上用正则去掉alias中的括号即可。

2. genChildren的返回值应该是一个数组的字符串，而不是join(',')之后的字符串。原来的处理会更改了_c的传参，影响到children后面的参数。

3. genElement最后生成的code中，第一个逗号位置错了，后面的class最好用引号括起来，在es6中是关键字，导致编译出错。